### PR TITLE
Removed setTimeOut function

### DIFF
--- a/src/loggly.tracker.js
+++ b/src/loggly.tracker.js
@@ -84,42 +84,42 @@
 
             var self = this;
 
-            setTimeout(function() {
-                if(type === 'string') {
-                    data = {
-                        'text': data
-                    };
-                } else {
-                    if(data.logglyCollectorDomain) {
-                        self.logglyCollectorDomain = data.logglyCollectorDomain;
-                        return;
-                    }
-                
-		    if(data.sendConsoleErrors !== undefined) {
-		       	setSendConsoleError(self, data.sendConsoleErrors);
-		    }
-		    
-		    if(data.tag){
-		    	setTag(self, data.tag);
-		    }
-				
-                    if(data.logglyKey) {
-                        setKey(self, data.logglyKey);
-                        return;
-                    }
-                
-                    if(data.session_id) {
-                        self.setSession(data.session_id);
-                        return;
-                    }
-                }
-                
-                if(!self.key) {
+            
+	    if(type === 'string') {
+                data = {
+                    'text': data
+                };
+            } else {
+                if(data.logglyCollectorDomain) {
+                    self.logglyCollectorDomain = data.logglyCollectorDomain;
                     return;
                 }
+        
+	        if(data.sendConsoleErrors !== undefined) {
+	       	    setSendConsoleError(self, data.sendConsoleErrors);
+	        }
+	    
+	        if(data.tag){
+	    	    setTag(self, data.tag);
+	        }
+			
+                if(data.logglyKey) {
+                    setKey(self, data.logglyKey);
+                    return;
+                }
+        
+                if(data.session_id) {
+                    self.setSession(data.session_id);
+                    return;
+                }
+            }
+        
+            if(!self.key) {
+                return;
+            }
+    
+            self.track(data);
             
-                self.track(data);
-            }, 0);
             
         },
         track: function(data) {


### PR DESCRIPTION
due to setTimeOut function, the code inside it, was running asynchronously and causing delay in setting up of the loggly.tracker.js variables like key, sendConsoleErrors etc. which is stopping the logs to be sent to Loggly during the page load.